### PR TITLE
GroupId fix for 'jakarta'

### DIFF
--- a/src/main/java/org/glassfish/spec/Spec.java
+++ b/src/main/java/org/glassfish/spec/Spec.java
@@ -59,6 +59,16 @@ import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 public class Spec {
 
     /**
+     * GroupId used for JavaEE specs.
+     */
+    public static final String JAVAX_GROUP_ID = "javax.";
+
+    /**
+     * GroupId used for JakartaEE specs.
+     */
+    public static final String JAKARTA_GROUP_ID = "jakarta.";
+
+    /**
      * The Spec Artifact.
      */
     private Artifact artifact;
@@ -121,7 +131,7 @@ public class Spec {
     /**
      * The Spec GroupId Prefix.
      */
-    private String groupIdPrefix = "javax.";
+    private String groupIdPrefix;
 
     /**
      * The Spec Final flag.
@@ -388,8 +398,8 @@ public class Spec {
                         API_SUFFIX));
             }
 
-            // verify that apiPackage starts with groupIdPrefix
-            if (!apiPackage.startsWith(groupIdPrefix)) {
+            // verify that apiPackage starts with javax
+            if (!apiPackage.startsWith(JAVAX_GROUP_ID)) {
                 errors.add(String.format(
                         "WARNING: API packages (%s) must start with \"%s\"",
                         apiPackage,

--- a/src/main/java/org/glassfish/spec/maven/CheckModuleMojo.java
+++ b/src/main/java/org/glassfish/spec/maven/CheckModuleMojo.java
@@ -83,6 +83,12 @@ public final class CheckModuleMojo extends AbstractMojo {
     private boolean ignoreErrors;
 
     /**
+     * Mode. Allowed values are "javaee", "jakarta"
+     */
+    @Parameter(property = "specMode", defaultValue = "javaee")
+    private String specMode;
+
+    /**
      * Spec.
      */
     @Parameter(property = "spec", required = true)
@@ -102,6 +108,8 @@ public final class CheckModuleMojo extends AbstractMojo {
             if (spec == null) {
                 spec = new Spec();
             }
+
+            spec.setGroupIdPrefix(specMode.equals("jakarta") ? Spec.JAKARTA_GROUP_ID : Spec.JAVAX_GROUP_ID);
             spec.setArtifact(new Artifact(
                     project.getGroupId(),
                     project.getArtifactId(),

--- a/src/main/java/org/glassfish/spec/maven/CommandLineMojo.java
+++ b/src/main/java/org/glassfish/spec/maven/CommandLineMojo.java
@@ -98,10 +98,10 @@ public final class CommandLineMojo extends AbstractMojo {
     private String implNamespace;
 
     /**
-     * GroupId prefix.
+     * Mode. Allowed values are "javaee", "jakarta"
      */
-    @Parameter(property = "groupIdPrefix", defaultValue = "javax.")
-    private String groupIdPrefix;
+    @Parameter(property = "specMode", defaultValue = "javaee")
+    private String specMode;
 
     /**
      * API package.
@@ -224,6 +224,7 @@ public final class CommandLineMojo extends AbstractMojo {
             printParam("specbuild", "num\tbuild number of spec API jar file");
             printParam("newimplversion", "vers\tversion number of the implementation when final");
             printParam("implbuild", "num\tbuild number of implementation jar file");
+            printParam("specMode", "specMode\t'javaee' or 'jakarta'");
             return;
         }
 
@@ -236,6 +237,7 @@ public final class CommandLineMojo extends AbstractMojo {
                 fis = new FileInputStream(properties);
                 p.load(fis);
                 fis.close();
+                specMode = p.getProperty("SPEC_MODE", specMode);
                 apiPackage = p.getProperty("API_PACKAGE", apiPackage);
                 implNamespace = p.getProperty("IMPL_NAMESPACE", implNamespace);
                 jarType = p.getProperty("JAR_TYPE", jarType);
@@ -325,7 +327,7 @@ public final class CommandLineMojo extends AbstractMojo {
                 jarType = JarType.api.name();
             }
 
-            groupIdPrefix = prompt("Enter the groupId prefix (e.g., javax.)");
+            specMode = prompt("Enter the spec mode ('javaee' or 'jakarta')");
             apiPackage = prompt("Enter the main API package (e.g., javax.wombat)");
             specVersion = prompt("Enter the version number of the JCP specification");
 
@@ -349,7 +351,7 @@ public final class CommandLineMojo extends AbstractMojo {
         // TODO remove mojo parameters and replace with spec.
         Spec spec = new Spec();
         spec.setArtifact(artifact);
-        spec.setGroupIdPrefix(groupIdPrefix);
+        spec.setGroupIdPrefix(specMode.equals("jakarta") ? Spec.JAKARTA_GROUP_ID : Spec.JAVAX_GROUP_ID);
         spec.setSpecVersion(specVersion);
         spec.setNewSpecVersion(newSpecVersion);
         spec.setSpecImplVersion(specImplVersion);


### PR DESCRIPTION
This PR adds support for 'jakarta' groupId. The default behaviour is not changed. To use the plugin in Jakarta mode the following config should be added:

```
<configuration>
    <specMode>jakarta</specMode>
    <spec>
        ...
    </spec>
</configuration>
```